### PR TITLE
set viewer to latched

### DIFF
--- a/src/tiny_slam/tiny_slam.cpp
+++ b/src/tiny_slam/tiny_slam.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
   scan_observer.subscribe(slam);
 
   std::shared_ptr<RvizGridViewer> viewer(
-    new RvizGridViewer(nh.advertise<nav_msgs::OccupancyGrid>("/map", 5),
+    new RvizGridViewer(nh.advertise<nav_msgs::OccupancyGrid>("/map", 5, true),
                        ros_map_publishing_rate, frame_odom, frame_robot_pose));
   slam->set_viewer(viewer);
 


### PR DESCRIPTION
Hi, I'm using tiny_slam in ROS melodic to create a map from a rosbag file. The problem I have is that everytime I try to save the map, the `map_saver` just keeps on waiting for any incoming messages on the /map-topic but nothing happens.
I found out that if one sets the viewer in tiny_slam.cpp to latched by adding a `true` it works the way it's meant to, i guess.